### PR TITLE
Separate parts

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,59 +1,4 @@
-const { promisify } = require("util");
-const stream = require("stream");
-const fs = require("fs");
-const fsPromises = require("fs/promises");
-const path = require("path");
-const got = require("got");
-
-const { getBody, getTracks, validateTracks } = require("./lib");
-
-const pipeline = promisify(stream.pipeline);
-
-const getId = (id) => {
-  const adjusted = id - 1;
-  const prefix = adjusted > 9 ? "" : "0";
-  return prefix + adjusted;
-};
-
-const getUrl = async (track) => {
-  const { body } = await got.post(
-    "https://autoplaylist.top/api-us/getMp3Link",
-    {
-      json: { chapterId: track.chapter_id, serverType: 1 },
-      responseType: "json",
-    }
-  );
-  return body.link_mp3;
-};
-
-const downloadTrack = async (track, dir) => {
-  let [_book, _, filename] = track.chapter_link_dropbox.split("/");
-
-  const fileparts = filename.split(" - ");
-  const filestats = path.parse(filename);
-  const book = fileparts[0];
-
-  if (fileparts.length === 2) {
-    filename = filename.replace(filestats.name, `${getId(track.track)}`);
-  } else if (fileparts.length === 3) {
-    filename = filename
-      .replace(
-        `${fileparts[0]} - ${fileparts[1]} - `,
-        `${getId(track.track)} - `
-      )
-      .replace(`-${track.chapter_id}`, "");
-  }
-
-  const dirpath = path.join(dir, book);
-  const filepath = path.join(dirpath, filename);
-  await fsPromises.mkdir(dirpath, { recursive: true });
-
-  const url = track.url === "NA" ? await getUrl(track) : track.url;
-  await pipeline(
-    got.stream(url),
-    fs.createWriteStream(filepath, { flag: "wx" })
-  );
-};
+const { getBody, getTracks, validateTracks, downloadTrack } = require("./lib");
 
 const main = async () => {
   const url = "https://tokybook.com/tales-from-earthsea/";
@@ -62,6 +7,6 @@ const main = async () => {
   const unvalidatedTracks = getTracks(body);
   const tracks = validateTracks(unvalidatedTracks);
   await Promise.all(tracks.map((track) => downloadTrack(track, dir)));
-}
+};
 
 module.exports = { main };

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,81 @@
+const { promisify } = require("util");
+const stream = require("stream");
+const fs = require("fs");
+const fsPromises = require("fs/promises");
+const path = require("path");
+const got = require("got");
+
+const pipeline = promisify(stream.pipeline);
+
+const getId = (id) => {
+  const adjusted = id - 1;
+  const prefix = adjusted > 9 ? "" : "0";
+  return prefix + adjusted;
+};
+
+const getTracks = (html) => {
+  const unparsedWithTrailingCommas = html
+    .match(/tracks = \[[.\s\S]*?\]/)[0]
+    .replace("tracks = ", "");
+  const unparsed = unparsedWithTrailingCommas.replace(
+    /\,(?!\s*?[\{\[\"\'\w])/g,
+    ""
+  );
+  const tracks = JSON.parse(unparsed);
+
+  return tracks;
+};
+
+const getUrl = async (track) => {
+  const { body } = await got.post(
+    "https://autoplaylist.top/api-us/getMp3Link",
+    {
+      json: { chapterId: track.chapter_id, serverType: 1 },
+      responseType: "json",
+    }
+  );
+  return body.link_mp3;
+};
+
+const validateTracks = (tracks) => tracks.filter((track) => track.url);
+
+const downloadTrack = async (track, dir) => {
+  let [_book, _, filename] = track.chapter_link_dropbox.split("/");
+
+  const fileparts = filename.split(" - ");
+  const filestats = path.parse(filename);
+  const book = fileparts[0];
+
+  if (fileparts.length === 2) {
+    filename = filename.replace(filestats.name, `${getId(track.track)}`);
+  } else if (fileparts.length === 3) {
+    filename = filename
+      .replace(
+        `${fileparts[0]} - ${fileparts[1]} - `,
+        `${getId(track.track)} - `
+      )
+      .replace(`-${track.chapter_id}`, "");
+  }
+
+  const dirpath = path.join(dir, book);
+  const filepath = path.join(dirpath, filename);
+  await fsPromises.mkdir(dirpath, { recursive: true });
+
+  const url = track.url === "NA" ? await getUrl(track) : track.url;
+  await pipeline(
+    got.stream(url),
+    fs.createWriteStream(filepath, { flag: "wx" })
+  );
+};
+
+const main = async () => {
+  const url = "https://tokybook.com/tales-from-earthsea/";
+  const dir = "/Users/pat/Documents/Audiobooks";
+  const response = await got(url);
+  const { body } = response;
+  const unvalidatedTracks = getTracks(body);
+  const tracks = validateTracks(unvalidatedTracks);
+  await Promise.all(tracks.map((track) => downloadTrack(track, dir)));
+}
+
+module.exports = { main };

--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,8 @@ const fsPromises = require("fs/promises");
 const path = require("path");
 const got = require("got");
 
+const { getBody } = require('./lib');
+
 const pipeline = promisify(stream.pipeline);
 
 const getId = (id) => {
@@ -71,8 +73,7 @@ const downloadTrack = async (track, dir) => {
 const main = async () => {
   const url = "https://tokybook.com/tales-from-earthsea/";
   const dir = "/Users/pat/Documents/Audiobooks";
-  const response = await got(url);
-  const { body } = response;
+  const body = await getBody(url);
   const unvalidatedTracks = getTracks(body);
   const tracks = validateTracks(unvalidatedTracks);
   await Promise.all(tracks.map((track) => downloadTrack(track, dir)));

--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ const fsPromises = require("fs/promises");
 const path = require("path");
 const got = require("got");
 
-const { getBody } = require('./lib');
+const { getBody, getTracks } = require('./lib');
 
 const pipeline = promisify(stream.pipeline);
 
@@ -13,19 +13,6 @@ const getId = (id) => {
   const adjusted = id - 1;
   const prefix = adjusted > 9 ? "" : "0";
   return prefix + adjusted;
-};
-
-const getTracks = (html) => {
-  const unparsedWithTrailingCommas = html
-    .match(/tracks = \[[.\s\S]*?\]/)[0]
-    .replace("tracks = ", "");
-  const unparsed = unparsedWithTrailingCommas.replace(
-    /\,(?!\s*?[\{\[\"\'\w])/g,
-    ""
-  );
-  const tracks = JSON.parse(unparsed);
-
-  return tracks;
 };
 
 const getUrl = async (track) => {

--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ const fsPromises = require("fs/promises");
 const path = require("path");
 const got = require("got");
 
-const { getBody, getTracks } = require('./lib');
+const { getBody, getTracks, validateTracks } = require("./lib");
 
 const pipeline = promisify(stream.pipeline);
 
@@ -25,8 +25,6 @@ const getUrl = async (track) => {
   );
   return body.link_mp3;
 };
-
-const validateTracks = (tracks) => tracks.filter((track) => track.url);
 
 const downloadTrack = async (track, dir) => {
   let [_book, _, filename] = track.chapter_link_dropbox.split("/");

--- a/index.js
+++ b/index.js
@@ -1,83 +1,9 @@
-const { promisify } = require("util");
-const stream = require("stream");
-const fs = require("fs");
-const fsPromises = require("fs/promises");
-const path = require("path");
-const got = require("got");
 
-const pipeline = promisify(stream.pipeline);
-
-const getId = (id) => {
-  const adjusted = id - 1;
-  const prefix = adjusted > 9 ? "" : "0";
-  return prefix + adjusted;
-};
-
-const getTracks = (html) => {
-  const unparsedWithTrailingCommas = html
-    .match(/tracks = \[[.\s\S]*?\]/)[0]
-    .replace("tracks = ", "");
-  const unparsed = unparsedWithTrailingCommas.replace(
-    /\,(?!\s*?[\{\[\"\'\w])/g,
-    ""
-  );
-  const tracks = JSON.parse(unparsed);
-
-  return tracks;
-};
-
-const getUrl = async (track) => {
-  const { body } = await got.post(
-    "https://autoplaylist.top/api-us/getMp3Link",
-    {
-      json: { chapterId: track.chapter_id, serverType: 1 },
-      responseType: "json",
-    }
-  );
-  return body.link_mp3;
-};
-
-const validateTracks = (tracks) => tracks.filter((track) => track.url);
-
-const downloadTrack = async (track, dir) => {
-  let [_book, _, filename] = track.chapter_link_dropbox.split("/");
-
-  const fileparts = filename.split(" - ");
-  const filestats = path.parse(filename);
-  const book = fileparts[0];
-
-  if (fileparts.length === 2) {
-    filename = filename.replace(filestats.name, `${getId(track.track)}`);
-  } else if (fileparts.length === 3) {
-    filename = filename
-      .replace(
-        `${fileparts[0]} - ${fileparts[1]} - `,
-        `${getId(track.track)} - `
-      )
-      .replace(`-${track.chapter_id}`, "");
-  }
-
-  const dirpath = path.join(dir, book);
-  const filepath = path.join(dirpath, filename);
-  await fsPromises.mkdir(dirpath, { recursive: true });
-
-  const url = track.url === "NA" ? await getUrl(track) : track.url;
-  await pipeline(
-    got.stream(url),
-    fs.createWriteStream(filepath, { flag: "wx" })
-  );
-};
+const { main } = require("./cli");
 
 (async () => {
-  const url = "https://tokybook.com/tales-from-earthsea/";
-  const dir = "/Users/pat/Documents/Audiobooks";
-
   try {
-    const response = await got(url);
-    const { body } = response;
-    const unvalidatedTracks = getTracks(body);
-    const tracks = validateTracks(unvalidatedTracks);
-    await Promise.all(tracks.map((track) => downloadTrack(track, dir)));
+    await main();
   } catch (error) {
     console.error(error);
   }

--- a/lib/downloadTrack.js
+++ b/lib/downloadTrack.js
@@ -1,0 +1,56 @@
+const { promisify } = require("util");
+const stream = require("stream");
+const path = require("path");
+const fsPromises = require("fs/promises");
+const got = require("got");
+const fs = require("fs");
+
+const pipeline = promisify(stream.pipeline)
+
+const getId = (id) => {
+  const adjusted = id - 1;
+  const prefix = adjusted > 9 ? "" : "0";
+  return prefix + adjusted;
+};
+
+const getUrl = async (track) => {
+  const { body } = await got.post(
+    "https://autoplaylist.top/api-us/getMp3Link",
+    {
+      json: { chapterId: track.chapter_id, serverType: 1 },
+      responseType: "json",
+    }
+  );
+  return body.link_mp3;
+};
+
+const downloadTrack = async (track, dir) => {
+  let [_book, _, filename] = track.chapter_link_dropbox.split("/");
+
+  const fileparts = filename.split(" - ");
+  const filestats = path.parse(filename);
+  const book = fileparts[0];
+
+  if (fileparts.length === 2) {
+    filename = filename.replace(filestats.name, `${getId(track.track)}`);
+  } else if (fileparts.length === 3) {
+    filename = filename
+      .replace(
+        `${fileparts[0]} - ${fileparts[1]} - `,
+        `${getId(track.track)} - `
+      )
+      .replace(`-${track.chapter_id}`, "");
+  }
+
+  const dirpath = path.join(dir, book);
+  const filepath = path.join(dirpath, filename);
+  await fsPromises.mkdir(dirpath, { recursive: true });
+
+  const url = track.url === "NA" ? await getUrl(track) : track.url;
+  await pipeline(
+    got.stream(url),
+    fs.createWriteStream(filepath, { flag: "wx" })
+  );
+};
+
+module.exports = downloadTrack;

--- a/lib/getBody.js
+++ b/lib/getBody.js
@@ -1,0 +1,9 @@
+const got = require("got");
+
+const getBody = async (url) => {
+  const response = await got(url);
+  const { body } = response;
+  return body;
+}
+
+module.exports = getBody;

--- a/lib/getTracks.js
+++ b/lib/getTracks.js
@@ -1,0 +1,14 @@
+const getTracks = (html) => {
+  const unparsedWithTrailingCommas = html
+    .match(/tracks = \[[.\s\S]*?\]/)[0]
+    .replace("tracks = ", "");
+  const unparsed = unparsedWithTrailingCommas.replace(
+    /\,(?!\s*?[\{\[\"\'\w])/g,
+    ""
+  );
+  const tracks = JSON.parse(unparsed);
+
+  return tracks;
+};
+
+module.exports = getTracks;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const getBody = require('./getBody');
 const getTracks = require('./getTracks');
+const validateTracks = require('./validateTracks');
 
-module.exports = { getBody, getTracks };
+module.exports = { getBody, getTracks, validateTracks };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const getBody = require('./getBody');
 const getTracks = require('./getTracks');
 const validateTracks = require('./validateTracks');
+const downloadTrack = require('./downloadTrack');
 
-module.exports = { getBody, getTracks, validateTracks };
+module.exports = { getBody, getTracks, validateTracks, downloadTrack };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 const getBody = require('./getBody');
+const getTracks = require('./getTracks');
 
-module.exports = { getBody };
+module.exports = { getBody, getTracks };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,3 @@
+const getBody = require('./getBody');
+
+module.exports = { getBody };

--- a/lib/validateTracks.js
+++ b/lib/validateTracks.js
@@ -1,0 +1,3 @@
+const validateTracks = (tracks) => tracks.filter((track) => track.url);
+
+module.exports = validateTracks;


### PR DESCRIPTION
Separates the pieces of the CLI into a `lib` module with a barrel file, and a `cli.js` file for composing the pieces of `lib` that create a CLI action.

Didn't modify the code, except for adding a function called `getBody`, so that the business logic can stay in `lib/*`.

This PR is most easily reviewed commit-by-commit.

Closes https://github.com/the-pat/tokybook-dl/issues/2